### PR TITLE
DEV2-3477: Propagate `nat_ips` setting.

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -46,6 +46,7 @@ module "gke_cluster_tabnine" {
 | <a name="input_exclude_kubernetes_manifest"></a> [exclude\_kubernetes\_manifest](#input\_exclude\_kubernetes\_manifest) | Exclude kubernetes manifest installations. This should be off during initial installation | `bool` | `false` | no |
 | <a name="input_gke_master_authorized_networks"></a> [gke\_master\_authorized\_networks](#input\_gke\_master\_authorized\_networks) | n/a | <pre>list(object({<br>    cidr_block   = string,<br>    display_name = string<br>  }))</pre> | n/a | yes |
 | <a name="input_min_gpu_machines"></a> [min\_gpu\_machines](#input\_min\_gpu\_machines) | Minimum number of GPU instances | `number` | `1` | no |
+| <a name="input_nat_ips"></a> [nat\_ips](#input\_nat\_ips) | nat\_ips (list(number), optional): Self-links of NAT IPs. | `list(number)` | `[]` | no |
 | <a name="input_pre_shared_cert_name"></a> [pre\_shared\_cert\_name](#input\_pre\_shared\_cert\_name) | Use this if you already uploaded a pre-shared cert | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix all resources names | `string` | `"tabnine-self-hosted"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |

--- a/modules/cluster/cloud_router.tf
+++ b/modules/cluster/cloud_router.tf
@@ -6,7 +6,10 @@ module "cloud_router" {
   project = var.project_id
   region  = var.region
 
-  nats = [{
-    name = format("%s-nat-gateway", var.prefix)
-  }]
+  nats = [
+    {
+      name    = format("%s-nat-gateway", var.prefix)
+      nat_ips = var.nat_ips
+    }
+  ]
 }

--- a/modules/cluster/vars.tf
+++ b/modules/cluster/vars.tf
@@ -74,6 +74,11 @@ variable "gke_master_authorized_networks" {
   }))
 }
 
+variable "nat_ips" {
+  type        = list(number)
+  default     = []
+  description = "nat_ips (list(number), optional): Self-links of NAT IPs."
+}
 locals {
   db_master_zone             = var.db_master_zone != null ? var.db_master_zone : data.google_compute_zones.available.names[0]
   private_service_connect_ip = "10.10.40.1"


### PR DESCRIPTION
This PR enables the propagation of `nat_ips` setting from our `cluster` module to its underlying [`terraform-google-cloud-router`](https://github.com/terraform-google-modules/terraform-google-cloud-router/blob/master/variables.tf)