### PR TITLE
DEV2-6886: fixing kubernetes version to latest

### DIFF
--- a/modules/cluster/gke.tf
+++ b/modules/cluster/gke.tf
@@ -1,7 +1,7 @@
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   project_id                    = var.project_id
-  kubernetes_version            = "1.30.3-gke.1451000"
+  kubernetes_version            = "latest"
   name                          = format("%s-gke", var.prefix)
   region                        = var.region
   network                       = module.vpc.network.network_name


### PR DESCRIPTION
Sometimes `tf apply` fails because the hardcoded kubernetes version is no longer supported.
Setting it to `latest` should alleviate this issue.